### PR TITLE
Document Ruby 1.8 requirement. Fixes #1.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -55,6 +55,7 @@ run your code, then you'll see where the calls to Array#select and
 
 * event_hook
 * RubyInline
+* Ruby 1.8
 
 == INSTALL:
 


### PR DESCRIPTION
zenprofile requires node.h, which doesn't exist in Ruby 1.9 or 2.0.
